### PR TITLE
added policies to the helm chart so they are created on deploy

### DIFF
--- a/chart/templates/policies.yaml
+++ b/chart/templates/policies.yaml
@@ -1,0 +1,14 @@
+{{- range $name, $spec := .Values.policies -}}
+apiVersion: policy.jspolicy.com/v1beta1
+kind: JsPolicy
+metadata:
+  name: {{ $name | quote }}
+  labels:
+    app: {{ template "jspolicy.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+spec:
+  {{- $spec | toYaml | nindent 2 }}
+---
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -53,3 +53,16 @@ serviceMonitor:
   scrapeTimeout: 30s
   labels: {}
   
+# Create policies as part of the chart
+# policies is a map:
+#   the key is the name of the policy
+#   the value is the policy spec
+policies: {}
+#  "block-default-namespace.example.com" :
+#    operations: ["CREATE"]
+#    resources: ["*"]
+#    scope: Namespaced
+#    javascript: |
+#      if (request.namespace === "default") {
+#        deny("Creation of resources within the default namespace is not allowed!");
+#      }


### PR DESCRIPTION
It would be nice if the chart created policies for us as well. Added policies.yaml to the chart templates do just that.