### PR TITLE
Add priority class value

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app: {{ template "jspolicy.fullname" . }}
         release: {{ .Release.Name }}
     spec:
+      priorityClassName: {{ .Values.priorityClassName }}
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "jspolicy.serviceAccountName" . }}
       {{- if .Values.imagePullSecrets }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,7 +67,7 @@ securityContext:
   runAsGroup: 1000
   runAsNonRoot: true
 
-priorityClassName: system-cluster-critical
+priorityClassName: ""
 
 ##  Affinity for pods assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,6 +67,8 @@ securityContext:
   runAsGroup: 1000
   runAsNonRoot: true
 
+priorityClassName: system-cluster-critical
+
 ##  Affinity for pods assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##


### PR DESCRIPTION
## Description 

In this PR I want to add priorityClassName to jsPolicy Helm Chart. 
I want to do it because in some system jsPolicy can work as system critical component and to make it more privileged I added priorityClassName value to the jsPolicy Chart.
I added `priorityClassName` without any default values because usually, jsPolicy may not need this privilege. 


## Testing 

The command which I use to deploy jsPolicy Helm Chart - `helm install jspolicy . --set priorityClassName=system-cluster-critical`

* There you can see that `priorityClassName` was added successfully to the pods
<img width="657" alt="Screenshot 2023-02-11 at 12 17 48" src="https://user-images.githubusercontent.com/73275046/218252721-3ed0d773-c015-49e7-93c2-7260bc1b6eda.png">

* And Deployment also has `priorityClassName` value

<img width="464" alt="Screenshot 2023-02-11 at 12 18 59" src="https://user-images.githubusercontent.com/73275046/218252753-7e1d8bbb-253a-43f2-afc8-792e0c7cbfff.png">

* There you can see that without any values jsPolicy can be successfully created. Commnad which I used `helm install jspolicy .`.
<img width="530" alt="Screenshot 2023-02-11 at 12 32 28" src="https://user-images.githubusercontent.com/73275046/218253457-d0eebf6e-9cca-4cd3-af6f-730c9f1fe11c.png">
