### PR TITLE
Updating documentation on the crds

### DIFF
--- a/docs/pages/getting-started/cleanup.mdx
+++ b/docs/pages/getting-started/cleanup.mdx
@@ -23,11 +23,12 @@ kubectl delete validatingwebhookconfiguration jspolicy
 ```
 :::
 
-
-## Delete CRDs (optional)
+:::caution Delete CRDs
+Some CRDs may still be in place which may cause clusters to fail to respond to API requests due to the failing webhook. In such case you may need to delete the resources:
 ```bash
 kubectl api-resources --api-group='policy.jspolicy.com' -o name | xargs kubectl delete crd
 ```
+:::
 
 :::warning Data Loss
 Deleting the jsPolicy CRDs will also remove all jsPolicy objects inside your cluster, i.e. all `JsPolicy`, `JsPolicyBundle`, and `JsPolicyViolations` objects.


### PR DESCRIPTION
Uninstalling may require the crds to be removes for the same reason you'd need to remove the Webhooks. We ran into an issue where even though the webhooks were removed, policies defined in the crds wouldn't allow Loft to function properly. This required us to remove the crds so that Loft would function again. Once the crds were removed, the errors outlined in https://github.com/loft-sh/jspolicy/issues/89 subsided and Loft became functional again.

Addresses https://github.com/loft-sh/jspolicy/issues/89