### PR TITLE
refactor(pdp): change apiVersion to policy/v1

### DIFF
--- a/chart/templates/pdb.yaml
+++ b/chart/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.create }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: jspolicy


### PR DESCRIPTION
policy/v1beta1 API version of PodDisruptionBudget is no longer served as of k8s v1.25

closes #98