### PR TITLE
fix: editURL after branch migration to main

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -72,7 +72,7 @@ module.exports = {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/loft-sh/jspolicy/edit/master/docs/',
+            'https://github.com/loft-sh/jspolicy/edit/main/docs/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
When visiting https://www.jspolicy.com/docs/quickstart and clicking on Edit button the link breaks by accessing `https://github.com/loft-sh/jspolicy/edit/master/docs/pages/quickstart.mdx`. 

Reason: master should be `main` branch as implemented in this PR 