### PR TITLE
feat: Add support for mounting extra volumes and add webhook URL override capability

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "jspolicy.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.jspolicy.extraVolumes }}
+      volumes:
+        {{- toYaml .Values.jspolicy.extraVolumes | nindent 8 }}
+      {{- end }}
       containers:
       - ports:
         - name: webhook
@@ -89,3 +93,7 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.jspolicy.resources | indent 10 }}
+        {{- if .Values.jspolicy.extraVolumeMounts }}
+        volumeMounts:
+          {{- toYaml .Values.jspolicy.extraVolumeMounts | nindent 10 }}
+        {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -28,6 +28,9 @@ jspolicy:
     requests:
       memory: 128Mi
       cpu: 50m
+  # extraVolumes and extraVolumeMounts allows mounting other volumes to the jsPolicy pod.
+  extraVolumes: []
+  extraVolumeMounts: []
 
 policyReports:
   enabled: false

--- a/pkg/controllers/jspolicy.go
+++ b/pkg/controllers/jspolicy.go
@@ -541,11 +541,16 @@ func (r *JsPolicyReconciler) syncMutatingWebhookConfiguration(ctx context.Contex
 	// Ensure webhook fields
 	webhook.Webhooks[0].Name = jsPolicy.Name
 	path := "/policy/" + jsPolicy.Name
-	webhook.Webhooks[0].ClientConfig.Service = &admissionregistrationv1.ServiceReference{
-		Name:      clienthelper.ServiceName(),
-		Namespace: namespace,
-		Path:      &path,
-		Port:      &port,
+	if url := clienthelper.WebhookURL(); url != "" {
+		url = url + path
+		webhook.Webhooks[0].ClientConfig.URL = &url
+	} else {
+		webhook.Webhooks[0].ClientConfig.Service = &admissionregistrationv1.ServiceReference{
+			Name:      clienthelper.ServiceName(),
+			Namespace: namespace,
+			Path:      &path,
+			Port:      &port,
+		}
 	}
 	webhook.Webhooks[0].ClientConfig.CABundle = r.CaBundle
 	if len(webhook.Webhooks[0].Rules) != 1 {
@@ -639,11 +644,16 @@ func (r *JsPolicyReconciler) syncValidatingWebhookConfiguration(ctx context.Cont
 	// Ensure webhook fields
 	webhook.Webhooks[0].Name = jsPolicy.Name
 	path := "/policy/" + jsPolicy.Name
-	webhook.Webhooks[0].ClientConfig.Service = &admissionregistrationv1.ServiceReference{
-		Name:      clienthelper.ServiceName(),
-		Namespace: namespace,
-		Path:      &path,
-		Port:      &port,
+	if url := clienthelper.WebhookURL(); url != "" {
+		url = url + path
+		webhook.Webhooks[0].ClientConfig.URL = &url
+	} else {
+		webhook.Webhooks[0].ClientConfig.Service = &admissionregistrationv1.ServiceReference{
+			Name:      clienthelper.ServiceName(),
+			Namespace: namespace,
+			Path:      &path,
+			Port:      &port,
+		}
 	}
 	webhook.Webhooks[0].ClientConfig.CABundle = r.CaBundle
 	if len(webhook.Webhooks[0].Rules) != 1 {

--- a/pkg/util/clienthelper/helper.go
+++ b/pkg/util/clienthelper/helper.go
@@ -20,6 +20,15 @@ func ServiceName() string {
 	return "jspolicy"
 }
 
+// WebhookURL returns the URL of the webhook service if it is set in the environment variable JS_POLICY_WEBHOOK_URL.
+// Otherwise, it returns an empty string which means a webhook service reference should be used.
+func WebhookURL() string {
+	if os.Getenv("JS_POLICY_WEBHOOK_URL") != "" {
+		return os.Getenv("JS_POLICY_WEBHOOK_URL")
+	}
+	return ""
+}
+
 func CurrentNamespace() (string, error) {
 	envNamespace := os.Getenv("KUBE_NAMESPACE")
 	if envNamespace != "" {


### PR DESCRIPTION
- Add ability to mount extra volumes and mounts to the jspolicy pod
- Allow specifying a Webhook URL that is used in place of a service reference