### PR TITLE
Oob changes

### DIFF
--- a/pkg/store/validatingwebhookconfiguration/store.go
+++ b/pkg/store/validatingwebhookconfiguration/store.go
@@ -2,16 +2,15 @@ package validatingwebhookconfiguration
 
 import (
 	"context"
-	"io/ioutil"
-	"path/filepath"
-
 	policyv1beta1 "github.com/loft-sh/jspolicy/pkg/apis/policy/v1beta1"
 	"github.com/loft-sh/jspolicy/pkg/util/certhelper"
 	"github.com/loft-sh/jspolicy/pkg/util/clienthelper"
+	"io/ioutil"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/util/certhelper/certhelper.go
+++ b/pkg/util/certhelper/certhelper.go
@@ -115,8 +115,10 @@ func generateCertificate(folder string, service string) error {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 	}
+	caTemplate := template
+	caTemplate.IsCA = true
 
-	cert, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	cert, err := x509.CreateCertificate(rand.Reader, template, caTemplate, &priv.PublicKey, priv)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
related to https://github.com/loft-sh/jspolicy/pull/109

Using a non-CA template as the parent seemingly causes an error to be returned when using jspolicy OOB.
`Error from server (InternalError): error when creating "/tmp/manifest": Internal error occurred: failed calling webhook "jspolicy.jspolicy.com": Post https://jspolicy.namespace.svc:443/crds?timeout=10s: x509: certificate signed by unknown authority (possibly because of "x509: invalid signature: parent certificate cannot sign this kind of certificate" while trying to verify candidate authority certificate "jspolicy").`