### PR TITLE
Oob changes

### DIFF
--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if ne (.Values.clusterRoleBinding).create false -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -15,3 +16,4 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.serviceAccount.clusterRole }}
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
       {{- if .Values.jspolicy.extraVolumes }}
       volumes:
         {{- toYaml .Values.jspolicy.extraVolumes | nindent 8 }}
+      {{- end }}
       {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints: {{- include "jspolicy.render" (dict "value" .Values.topologySpreadConstraints "context" .) | nindent 8 }}
       {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if ne (.Values.deployment).create false -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -106,3 +107,4 @@ spec:
         volumeMounts:
           {{- toYaml .Values.jspolicy.extraVolumeMounts | nindent 10 }}
         {{- end }}
+{{- end -}}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if ne (.Values.service).create false -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,3 +23,4 @@ spec:
   selector:
     app: {{ template "jspolicy.fullname" . }}
     release: {{ .Release.Name }}
+{{- end -}}


### PR DESCRIPTION
The first commit just fixes deployment rendering, which was broken in https://github.com/loft-sh/jspolicy/pull/100

The second commit makes all resources optional.  If <resourceType>.create is set and is false, then the resource will not be created.  This pattern defaults to true rather than requiring e.g. `clusterRoleBinding.created: true` be set in values.yaml; please let me know if that pattern is preferred.

This change allows us to leverage your chart to install CRDs in a cluster where jspolicy itself will be run outside of the cluster.