### PR TITLE
feat: support user-supplied annotations on service definition

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -4,6 +4,10 @@ kind: Service
 metadata:
   name: jspolicy
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.service.annotations }}
+  annotations:
+  {{- .Values.service.annotations | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ template "jspolicy.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
Allows for setting annotations on services; e.g. to specify an IP or IP pool to be used for a service